### PR TITLE
Do not use project.afterEvaluate as it may break configuration phase

### DIFF
--- a/src/main/kotlin/io/github/themrmilchmann/gradle/ecj/plugins/ECJPlugin.kt
+++ b/src/main/kotlin/io/github/themrmilchmann/gradle/ecj/plugins/ECJPlugin.kt
@@ -71,14 +71,14 @@ public class ECJPlugin : Plugin<Project> {
         val java = extensions.getByType(JavaPluginExtension::class.java)
         val javaToolchains = extensions.getByType(JavaToolchainService::class.java)
 
-        tasks.withType(JavaCompile::class.java) {
+        tasks.withType(JavaCompile::class.java).configureEach {
             /* Overwrite the javaCompiler to make sure that it is not inferred from the toolchain. */
             javaCompiler.set(null as JavaCompiler?)
 
             /* ECJ does not support generating JNI headers. Make sure the property is not used. */
             options.headerOutputDirectory.set(this@project.provider { null })
 
-            afterEvaluate {
+            doFirst {
                 val javaLauncher = if (java.toolchain.languageVersion.orNull?.canCompileOrRun(REQUIRED_JAVA_VERSION) == true) {
                     javaToolchains.launcherFor(java.toolchain).orNull ?: error("Could not get launcher for toolchain: ${java.toolchain}")
                 } else {


### PR DESCRIPTION
`afterEvaluate` usage breaks the build during configuration time when many different build.gradle files manipulate tasks eagerly/lazily.

![Screenshot from 2023-02-24 13-38-42](https://user-images.githubusercontent.com/20924106/221180975-18c24ff7-657f-455f-a6af-331136d8a55c.png)


This change also configures the ECJ compiler lazily now.